### PR TITLE
feat: 增加 OpenAI Images 接口支持

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -34,6 +34,7 @@
                 "options": [
                     "Gemini",
                     "OpenAI_Chat",
+                    "OpenAI_Images",
                     "Vertex_AI_Anonymous"
                 ],
                 "default": "Vertex_AI_Anonymous"
@@ -42,19 +43,19 @@
                 "description": "API密钥",
                 "type": "list",
                 "default": [],
-                "hint": "API Key列表。对于 OpenAI 规范，不需要填写Bearer 前缀，后端会自动拼接。VertexAI逆向可留空。"
+                "hint": "API Key列表。对于 OpenAI_Images 和 OpenAI_Chat，不需要填写Bearer 前缀，后端会自动拼接。VertexAI逆向可留空。"
             },
             "api_url": {
                 "description": "api_url",
                 "type": "string",
                 "default": "https://generativelanguage.googleapis.com/v1beta/models",
-                "hint": "Gemini示例：https://<base_url>/v1beta/models；OpenAI示例：http://<base_url>/v1/chat/completions；VertexAI官方与Gemini规范兼容，URL示例：https://aiplatform.googleapis.com/v1/publishers/google/models；VertexAI逆向可留空。"
+                "hint": "Gemini示例：https://<base_url>/v1beta/models；OpenAI_Images 官方示例：https://api.openai.com/v1/images；OpenAI_Chat 兼容层示例：http://<base_url>/v1/chat/completions；VertexAI官方与Gemini规范兼容，URL示例：https://aiplatform.googleapis.com/v1/publishers/google/models；VertexAI逆向可留空。"
             },
             "model": {
                 "description": "模型",
                 "type": "string",
                 "default": "gemini-3-pro-image-preview",
-                "hint": "默认值 gemini-3-pro-image-preview"
+                "hint": "默认值 gemini-3-pro-image-preview。OpenAI_Images 推荐填写 gpt-image-2。"
             },
             "stream": {
                 "description": "流式",
@@ -88,13 +89,14 @@
                 "options": [
                     "Gemini",
                     "OpenAI_Chat",
+                    "OpenAI_Images",
                     "Vertex_AI_Anonymous"
                 ],
                 "default": "Gemini"
             },
             "keys": {
                 "description": "API密钥",
-                "hint": "API Key列表。对于 OpenAI 规范，不需要填写Bearer 前缀，后端会自动拼接。VertexAI逆向可留空。",
+                "hint": "API Key列表。对于 OpenAI_Images 和 OpenAI_Chat，不需要填写Bearer 前缀，后端会自动拼接。VertexAI逆向可留空。",
                 "type": "list",
                 "default": []
             },
@@ -102,13 +104,13 @@
                 "description": "api_url",
                 "type": "string",
                 "default": "https://generativelanguage.googleapis.com/v1beta/models",
-                "hint": "Gemini示例：https://<base_url>/v1beta/models；OpenAI示例：http://<base_url>/v1/chat/completions；VertexAI官方与Gemini规范兼容，URL示例：https://aiplatform.googleapis.com/v1/publishers/google/models；VertexAI逆向可留空。"
+                "hint": "Gemini示例：https://<base_url>/v1beta/models；OpenAI_Images 官方示例：https://api.openai.com/v1/images；OpenAI_Chat 兼容层示例：http://<base_url>/v1/chat/completions；VertexAI官方与Gemini规范兼容，URL示例：https://aiplatform.googleapis.com/v1/publishers/google/models；VertexAI逆向可留空。"
             },
             "model": {
                 "description": "模型",
                 "type": "string",
                 "default": "gemini-3-pro-image-preview",
-                "hint": "默认值 gemini-3-pro-image-preview"
+                "hint": "默认值 gemini-3-pro-image-preview。OpenAI_Images 推荐填写 gpt-image-2。"
             },
             "stream": {
                 "description": "流式",
@@ -141,6 +143,7 @@
                 "options": [
                     "Gemini",
                     "OpenAI_Chat",
+                    "OpenAI_Images",
                     "Vertex_AI_Anonymous"
                 ],
                 "default": "Gemini",
@@ -148,7 +151,7 @@
             },
             "keys": {
                 "description": "API密钥",
-                "hint": "API Key列表。对于 OpenAI 规范，不需要填写Bearer 前缀，后端会自动拼接。VertexAI逆向可留空。",
+                "hint": "API Key列表。对于 OpenAI_Images 和 OpenAI_Chat，不需要填写Bearer 前缀，后端会自动拼接。VertexAI逆向可留空。",
                 "type": "list",
                 "default": []
             },
@@ -156,13 +159,13 @@
                 "description": "api_url",
                 "type": "string",
                 "default": "https://generativelanguage.googleapis.com/v1beta/models",
-                "hint": "Gemini示例：https://<base_url>/v1beta/models；OpenAI示例：http://<base_url>/v1/chat/completions；VertexAI官方与Gemini规范兼容，URL示例：https://aiplatform.googleapis.com/v1/publishers/google/models；VertexAI逆向可留空。"
+                "hint": "Gemini示例：https://<base_url>/v1beta/models；OpenAI_Images 官方示例：https://api.openai.com/v1/images；OpenAI_Chat 兼容层示例：http://<base_url>/v1/chat/completions；VertexAI官方与Gemini规范兼容，URL示例：https://aiplatform.googleapis.com/v1/publishers/google/models；VertexAI逆向可留空。"
             },
             "model": {
                 "description": "模型",
                 "type": "string",
                 "default": "gemini-3-pro-image-preview",
-                "hint": "默认值 gemini-3-pro-image-preview"
+                "hint": "默认值 gemini-3-pro-image-preview。OpenAI_Images 推荐填写 gpt-image-2。"
             },
             "stream": {
                 "description": "流式",

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,6 +3,7 @@ from .downloader import Downloader
 from .gemini import GeminiProvider
 from .http_manager import HttpManager
 from .openai_chat import OpenAIChatProvider
+from .openai_images import OpenAIImagesProvider
 from .vertex_ai_anonymous import VertexAIAnonymousProvider
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     "BaseProvider",
     "GeminiProvider",
     "OpenAIChatProvider",
+    "OpenAIImagesProvider",
     "VertexAIAnonymousProvider",
 ]

--- a/core/data.py
+++ b/core/data.py
@@ -2,12 +2,13 @@ from dataclasses import dataclass
 from typing import Literal
 
 # 常数
-DEF_OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+DEF_OPENAI_CHAT_API_URL = "https://api.openai.com/v1/chat/completions"
+DEF_OPENAI_IMAGES_API_URL = "https://api.openai.com/v1/images"
 DEF_GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 DEF_VERTEX_AI_ANONYMOUS_BASE_API = "https://cloudconsole-pa.clients6.google.com"
 
 # 类型枚举
-_API_Type = Literal["Gemini", "OpenAI_Chat", "Vertex_AI_Anonymous"]
+_API_Type = Literal["Gemini", "OpenAI_Chat", "OpenAI_Images", "Vertex_AI_Anonymous"]
 
 # 支持的文件格式
 SUPPORTED_FILE_FORMATS = (

--- a/core/openai_chat.py
+++ b/core/openai_chat.py
@@ -10,7 +10,7 @@ from .data import ProviderConfig
 
 
 class OpenAIChatProvider(BaseProvider):
-    """OpenAI Chat 提供商"""
+    """兼容 OpenAI-like Chat 图片返回服务的提供商"""
 
     api_type: str = "OpenAI_Chat"
 

--- a/core/openai_images.py
+++ b/core/openai_images.py
@@ -1,0 +1,180 @@
+import base64
+import json
+from io import BytesIO
+
+from curl_cffi import CurlMime
+from curl_cffi.requests.exceptions import Timeout
+from PIL import Image
+
+from astrbot.api import logger
+
+from .base import BaseProvider
+from .data import ProviderConfig
+
+
+class OpenAIImagesProvider(BaseProvider):
+    """OpenAI 官方 Images API 提供商"""
+
+    api_type: str = "OpenAI_Images"
+
+    async def _call_api(
+        self,
+        provider_config: ProviderConfig,
+        api_key: str,
+        image_b64_list: list[tuple[str, str]],
+        params: dict,
+    ) -> tuple[list[tuple[str, str]] | None, int | None, str | None]:
+        headers = {"Authorization": f"Bearer {api_key}"}
+        try:
+            if image_b64_list:
+                response = await self._post_image_edits(
+                    provider_config=provider_config,
+                    headers=headers,
+                    image_b64_list=image_b64_list,
+                    params=params,
+                )
+            else:
+                response = await self.session.post(
+                    url=self._build_api_url(provider_config.api_url, "generations"),
+                    headers={**headers, "Content-Type": "application/json"},
+                    json={
+                        "model": provider_config.model,
+                        "prompt": params.get("prompt", "anything"),
+                    },
+                    timeout=self.def_common_config.timeout,
+                    proxy=self.def_common_config.proxy,
+                )
+
+            result = response.json()
+            if response.status_code == 200:
+                images_result, err = self._parse_images_response(result)
+                if images_result:
+                    return images_result, 200, None
+                logger.warning(
+                    f"[BIG BANANA] OpenAI Images 请求成功，但未返回图片数据, 响应内容: {response.text[:1024]}"
+                )
+                return None, 200, err or "响应中未包含图片数据"
+
+            logger.error(
+                f"[BIG BANANA] OpenAI Images 图片生成失败，状态码: {response.status_code}, 响应内容: {response.text[:1024]}"
+            )
+            return (
+                None,
+                response.status_code,
+                self._extract_error_message(result)
+                or f"图片生成失败: 状态码 {response.status_code}",
+            )
+        except ValueError as e:
+            logger.error(f"[BIG BANANA] OpenAI Images 输入图片处理失败: {e}")
+            return None, None, str(e)
+        except Timeout as e:
+            logger.error(f"[BIG BANANA] OpenAI Images 网络请求超时: {e}")
+            return None, 408, "图片生成失败：响应超时"
+        except json.JSONDecodeError as e:
+            logger.error(
+                f"[BIG BANANA] OpenAI Images JSON反序列化错误: {e}，状态码：{response.status_code}，响应内容：{response.text[:1024]}"
+            )
+            return None, response.status_code, "图片生成失败：响应内容格式错误"
+        except Exception as e:
+            logger.error(f"[BIG BANANA] OpenAI Images 请求错误: {e}")
+            return None, None, "图片生成失败：程序错误"
+
+    async def _call_stream_api(
+        self,
+        provider_config: ProviderConfig,
+        api_key: str,
+        image_b64_list: list[tuple[str, str]],
+        params: dict,
+    ) -> tuple[list[tuple[str, str]] | None, int | None, str | None]:
+        logger.warning(
+            "[BIG BANANA] OpenAI_Images 暂不支持流式响应，将自动回退为非流式请求"
+        )
+        return await self._call_api(
+            provider_config=provider_config,
+            api_key=api_key,
+            image_b64_list=image_b64_list,
+            params=params,
+        )
+
+    async def _post_image_edits(
+        self,
+        provider_config: ProviderConfig,
+        headers: dict,
+        image_b64_list: list[tuple[str, str]],
+        params: dict,
+    ):
+        logger.info(
+            f"[BIG BANANA] OpenAI Images 正在请求 /images/edits，上传参考图 {len(image_b64_list)} 张"
+        )
+        data = {
+            "model": provider_config.model,
+            "prompt": params.get("prompt", "anything"),
+        }
+        multipart = CurlMime()
+        for index, (mime, b64_data) in enumerate(image_b64_list, start=1):
+            file_name, image_bytes, file_mime = self._normalize_image_payload(
+                mime, b64_data, index
+            )
+            multipart.addpart(
+                name="image",
+                content_type=file_mime,
+                filename=file_name,
+                data=image_bytes,
+            )
+        try:
+            return await self.session.post(
+                url=self._build_api_url(provider_config.api_url, "edits"),
+                headers=headers,
+                data=data,
+                multipart=multipart,
+                timeout=self.def_common_config.timeout,
+                proxy=self.def_common_config.proxy,
+            )
+        finally:
+            multipart.close()
+
+    @staticmethod
+    def _build_api_url(api_url: str, endpoint: str) -> str:
+        return f"{api_url.rstrip('/')}/{endpoint}"
+
+    @staticmethod
+    def _normalize_image_payload(
+        mime: str, b64_data: str, index: int
+    ) -> tuple[str, bytes, str]:
+        raw_bytes = base64.b64decode(b64_data)
+        try:
+            with Image.open(BytesIO(raw_bytes)) as img:
+                if getattr(img, "is_animated", False):
+                    img.seek(0)
+                img = img.convert("RGB")
+                buf = BytesIO()
+                img.save(buf, format="JPEG", quality=100)
+                return f"image_{index}.jpg", buf.getvalue(), "image/jpeg"
+        except Exception as e:
+            logger.warning(f"[BIG BANANA] OpenAI Images 输入图片归一化失败，将尝试使用原始字节: {e}")
+            if mime in {"image/jpeg", "image/jpg", "image/png", "image/webp"}:
+                ext = mime.split("/")[-1].replace("jpg", "jpeg")
+                return f"image_{index}.{ext}", raw_bytes, mime.replace("image/jpg", "image/jpeg")
+            raise ValueError("图片生成失败：存在不支持的输入图片格式，无法上传到 OpenAI Images API")
+
+    @staticmethod
+    def _parse_images_response(
+        result: dict,
+    ) -> tuple[list[tuple[str, str]] | None, str | None]:
+        image_result: list[tuple[str, str]] = []
+        for item in result.get("data", []):
+            b64_data = item.get("b64_json")
+            if b64_data:
+                image_result.append(("image/png", b64_data))
+        if image_result:
+            return image_result, None
+        return None, OpenAIImagesProvider._extract_error_message(result)
+
+    @staticmethod
+    def _extract_error_message(result: dict) -> str | None:
+        error = result.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if isinstance(message, str):
+                return message[:200]
+        return None


### PR DESCRIPTION
## 变更说明

基于当前 `main` 分支，新增官方 OpenAI 图片模型提供商 `OpenAI_Images`，用于对接 `gpt-image-2` 等图片模型。

本次改动的目标是将官方 OpenAI 图片模型主路径与现有 `OpenAI_Chat` 兼容层明确区分：
- `OpenAI_Images` 负责官方 `Images API`
- `OpenAI_Chat` 继续保留，用于兼容 OpenAI-like Chat 图片返回服务

## 主要内容

- 新增 `OpenAI_Images` provider
- 文生图走 `POST /v1/images/generations`
- 图生图走 `POST /v1/images/edits`
- 图生图使用 `multipart/form-data` 上传图片
- 输入参考图在上传前统一归一化为静态图片，优先收敛为 JPEG
- 从图片接口返回中解析 base64 图片数据
- 保留 `OpenAI_Chat`，但调整其说明为兼容层
- 更新配置 schema、README 和插件描述文案
- 新增官方 OpenAI 示例配置：
  - `api_type: OpenAI_Images`
  - `api_url: https://api.openai.com/v1/images`
  - `model: gpt-image-2`

## 兼容性说明

- `Gemini` 与 `Vertex_AI_Anonymous` 路径未做行为修改
- `OpenAI_Chat` 继续保留，不移除
- `OpenAI_Images` 为新增可选 provider
- 现有 Gemini 专属参数不会映射到 `OpenAI_Images`

## 备注

- `OpenAI_Images` 当前优先使用非流式调用
- 本次改动聚焦于官方 OpenAI 图片模型接入，不引入 `Responses API` 路线
- 图生图接口已按中转兼容性需求改为 multipart 上传实现

## 验证情况

- 已对修改后的 Python 文件进行静态编译检查
- 已核对 provider 注册、配置 schema 与 README，确保配置说明与代码行为一致
- 已在私聊场景中测试通过
