### PR TITLE
refactor(giftia): remove manual message caching and resolve bot nickname from config

### DIFF
--- a/core/runner.py
+++ b/core/runner.py
@@ -78,40 +78,6 @@ async def handle_drawing_result(
             )
             await event.send(event.chain_result(msg_chain))
 
-            # Cache the sent image message in giftia database
-            if giftia_inst and bot_name:
-                try:
-                    from datetime import datetime
-
-                    from data.plugins.astrbot_plugin_giftia.core.utils.schemas import (
-                        MessageData,
-                    )
-
-                    iso_string = datetime.now().isoformat()
-                    nickname = event.get_sender_name() or bot_name
-                    group_or_user_id = event.get_group_id() or event.get_sender_id()
-
-                    content_str = "[图片]"
-                    if result_urls:
-                        content_str = f" [图片:{result_urls[0]}]"
-
-                    msg_data = MessageData(
-                        nickname=nickname,
-                        user_id=event.get_self_id(),
-                        group_or_user_id=group_or_user_id,
-                        time=iso_string,
-                        message_id="",
-                        content=content_str,
-                        is_recalled=0,
-                    )
-                    await giftia_inst.data_cache.add_message(
-                        bot_name, group_or_user_id, msg_data
-                    )
-                except Exception as cache_err:
-                    logger.warning(
-                        f"[BIG BANANA] Failed to cache image message in giftia: {cache_err}"
-                    )
-
         # 开始生成 LLM 回复并排队
         reply_text = ""
         from astrbot.core.utils.session_lock import session_lock_manager
@@ -119,7 +85,8 @@ async def handle_drawing_result(
         async with session_lock_manager.acquire_lock(session_id):
             if giftia_inst and bot_name:
                 try:
-                    nickname = event.get_sender_name() or bot_name
+                    bot_conf = giftia_inst.bot_map.get(bot_name, {})
+                    nickname = bot_conf.get("nickname", bot_name)
                     group_or_user_id = event.get_group_id() or event.get_sender_id()
 
                     image_urls_for_llm = []

--- a/core/utils.py
+++ b/core/utils.py
@@ -101,10 +101,13 @@ def copy_local_file(src: str, temp_dir: Path) -> str:
         dest_path = temp_dir / dest_filename
         try:
             shutil.copy2(src_path, dest_path)
-            logger.debug(f"[BIG BANANA] Copied local temp image {src_path} to {dest_path}")
+            logger.debug(
+                f"[BIG BANANA] Copied local temp image {src_path} to {dest_path}"
+            )
             return str(dest_path)
         except Exception as e:
-            logger.error(f"[BIG BANANA] Failed to copy local image {src_path} to {dest_path}: {e}")
+            logger.error(
+                f"[BIG BANANA] Failed to copy local image {src_path} to {dest_path}: {e}"
+            )
 
     return src
-


### PR DESCRIPTION
适配giftia最新消息系统，由giftia插件本身接收图片并处理。

## Summary by Sourcery

为 Giftia 集成重构图像处理和机器人昵称解析。

增强内容：
- 移除 Giftia 中的手动图像消息缓存，将消息存储委托给 Giftia 自有的消息系统。
- 在 Giftia 交互中，从机器人配置而不是事件发送者名称解析机器人昵称。
- 整理与临时图像文件拷贝相关的日志，以提供更清晰的调试与错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor image handling and bot nickname resolution for Giftia integration.

Enhancements:
- Remove manual image message caching in Giftia, delegating message storage to Giftia's own message system.
- Resolve the bot nickname for Giftia interactions from the bot configuration instead of the event sender name.
- Tidy logging around temporary image file copying for clearer debug and error messages.

</details>