### PR TITLE
feat(llm_tools): add session-level background task limit for LLM medi…

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1263,6 +1263,12 @@
                 "type": "string",
                 "default": "",
                 "hint": "上游插件中的方法名；astrbot_plugin_giftia 定义的方法名为 on_drawing_complete。将以 event、result、params、unified_msg_origin、is_success 五个关键字参数调用。result 始终为 MessageChain；params 是最终生成参数；unified_msg_origin 是任务提交时的原会话标识快照；is_success 表示生成是否成功。未开启直接发送时 result 包含尚未发送的媒体或失败文本；开启后插件会先发送媒体，result 仅包含文字完成状态。方法可为同步函数、协程或异步生成器；显式返回 False 表示未接管并触发 BigBanana 回退处理，返回 True 或非 bool 值表示已接管。"
+            },
+            "llm_tool_max_tasks_per_session": {
+                "description": "每个会话后台任务上限",
+                "type": "int",
+                "default": 1,
+                "hint": "每个会话独立计算的 LLM 工具绘图/视频生成后台任务并发上限。设为 1 可防止同一会话后台任务无限堆积（设为 0 表示不限制）。"
             }
         }
     },

--- a/core/drawing/tasks.py
+++ b/core/drawing/tasks.py
@@ -14,6 +14,7 @@ class DrawingTaskManager:
         """初始化任务表。"""
         self.running_tasks: dict[str, asyncio.Task] = {}
         self._tracked_tasks: set[asyncio.Task] = set()
+        self.session_llm_tasks: dict[str, set[asyncio.Task]] = {}
 
     @staticmethod
     def build_task_id(event: AstrMessageEvent) -> str:
@@ -42,6 +43,37 @@ class DrawingTaskManager:
         """移除会话已结束的绘图任务。"""
         self.running_tasks.pop(task_id, None)
 
+    def get_session_llm_task_count(self, session_id: str) -> int:
+        """获取指定会话中正在运行的 LLM 工具后台任务数。"""
+        tasks = self.session_llm_tasks.get(session_id)
+        if not tasks:
+            if tasks is not None:
+                self.session_llm_tasks.pop(session_id, None)
+            return 0
+        running = [task for task in list(tasks) if not task.done()]
+        if not running:
+            self.session_llm_tasks.pop(session_id, None)
+            return 0
+        if len(running) != len(tasks):
+            self.session_llm_tasks[session_id] = set(running)
+        return len(running)
+
+    def start_llm_task(self, session_id: str, task: asyncio.Task) -> None:
+        """登记指定会话的 LLM 工具后台任务。"""
+        if session_id not in self.session_llm_tasks:
+            self.session_llm_tasks[session_id] = set()
+        self.session_llm_tasks[session_id].add(task)
+        self._tracked_tasks.add(task)
+        task.add_done_callback(lambda _t: self.finish_llm_task(session_id, task))
+
+    def finish_llm_task(self, session_id: str, task: asyncio.Task) -> None:
+        """移除指定会话已结束的 LLM 工具后台任务。"""
+        tasks = self.session_llm_tasks.get(session_id)
+        if tasks is not None:
+            tasks.discard(task)
+            if not tasks:
+                self.session_llm_tasks.pop(session_id, None)
+
     async def cancel_all(self) -> None:
         """取消并等待所有登记过且尚未结束的绘图任务。"""
         current_task = asyncio.current_task()
@@ -56,3 +88,4 @@ class DrawingTaskManager:
             await asyncio.gather(*tasks, return_exceptions=True)
         self.running_tasks.clear()
         self._tracked_tasks.clear()
+        self.session_llm_tasks.clear()

--- a/core/drawing/tasks.py
+++ b/core/drawing/tasks.py
@@ -57,13 +57,12 @@ class DrawingTaskManager:
         if len(running) != len(tasks):
             self.session_llm_tasks[session_id] = set(running)
         return len(running)
-
     def start_llm_task(self, session_id: str, task: asyncio.Task) -> None:
         """登记指定会话的 LLM 工具后台任务。"""
         if session_id not in self.session_llm_tasks:
             self.session_llm_tasks[session_id] = set()
         self.session_llm_tasks[session_id].add(task)
-        self._tracked_tasks.add(task)
+        # 仅负责会话级别 LLM 任务的登记与清理，通用任务追踪由上层 start(...) 负责
         task.add_done_callback(lambda _t: self.finish_llm_task(session_id, task))
 
     def finish_llm_task(self, session_id: str, task: asyncio.Task) -> None:

--- a/core/llm_tools/media_generation_base.py
+++ b/core/llm_tools/media_generation_base.py
@@ -42,6 +42,19 @@ class BaseMediaGenerationTool(FunctionTool[AstrAgentContext], ABC):
         if plugin.task_manager.is_running(task_id):
             return "该任务已在执行中，请勿重复操作。"
 
+        max_tasks = plugin.llm_tools_config.llm_tool_max_tasks_per_session
+        if (
+            max_tasks > 0
+            and plugin.task_manager.get_session_llm_task_count(unified_msg_origin)
+            >= max_tasks
+        ):
+            return (
+                f"当前会话已有正在执行的{self.media_name}生成任务（后台处理中），"
+                f"已达会话上限（{max_tasks}个）。"
+                f"请告知用户上一个{self.media_name}仍在生成中，需等待该任务完成后再开启新任务，"
+                f"切勿重复调用{self.generation_name}工具。"
+            )
+
         current_task = asyncio.current_task()
         if current_task:
             plugin.task_manager.start(task_id, current_task)
@@ -79,6 +92,7 @@ class BaseMediaGenerationTool(FunctionTool[AstrAgentContext], ABC):
                     )
                 )
                 plugin.task_manager.start(task_id, task)
+                plugin.task_manager.start_llm_task(unified_msg_origin, task)
                 if not use_background_callback:
                     return (
                         f"后台{self.generation_name}任务已启动，完成后会直接把"

--- a/core/schemas/common.py
+++ b/core/schemas/common.py
@@ -101,3 +101,6 @@ class LlmToolsConfig:
     """ 后台任务完成回调插件 """
     background_callback_method: str = ""
     """ 后台任务完成回调方法 """
+    llm_tool_max_tasks_per_session: int = 1
+    """ 每个会话 LLM 工具后台任务并发上限（0 为不限制） """
+

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -21,6 +21,8 @@ def test_llm_tool_presets_are_disabled_when_not_configured() -> None:
     assert LlmToolsConfig().llm_video_tool_preset_name == ""
     assert llm_tool_items["llm_tool_preset_name"]["default"] == ""
     assert llm_tool_items["llm_video_tool_preset_name"]["default"] == ""
+    assert LlmToolsConfig().llm_tool_max_tasks_per_session == 1
+    assert llm_tool_items["llm_tool_max_tasks_per_session"]["default"] == 1
 
 
 def test_empty_results_do_not_fall_back_by_default() -> None:

--- a/tests/test_llm_tool_session_limit.py
+++ b/tests/test_llm_tool_session_limit.py
@@ -1,0 +1,199 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from core.drawing.tasks import DrawingTaskManager
+from core.llm_tools.image_generation import BigBananaImageGenerationTool
+
+
+def test_task_manager_session_llm_task_tracking() -> None:
+    async def scenario() -> None:
+        manager = DrawingTaskManager()
+        session_id = "group_123"
+
+        assert manager.get_session_llm_task_count(session_id) == 0
+
+        fut = asyncio.Future()
+
+        async def worker():
+            await fut
+
+        task = asyncio.create_task(worker())
+
+        manager.start_llm_task(session_id, task)
+        assert manager.get_session_llm_task_count(session_id) == 1
+
+        fut.set_result(None)
+        await task
+        # Done callback will clean up automatically
+        assert manager.get_session_llm_task_count(session_id) == 0
+
+    asyncio.run(scenario())
+
+
+def test_task_manager_cancel_all_clears_session_llm_tasks() -> None:
+    async def scenario() -> None:
+        manager = DrawingTaskManager()
+        session_id = "group_123"
+
+        assert manager.get_session_llm_task_count(session_id) == 0
+
+        fut = asyncio.Future()
+
+        async def worker() -> None:
+            await fut
+
+        task1 = asyncio.create_task(worker())
+        task2 = asyncio.create_task(worker())
+
+        manager.start_llm_task(session_id, task1)
+        manager.start_llm_task(session_id, task2)
+        assert manager.get_session_llm_task_count(session_id) == 2
+
+        await manager.cancel_all()
+
+        assert manager.get_session_llm_task_count(session_id) == 0
+        assert manager.session_llm_tasks == {}
+
+        fut.set_result(None)
+        await asyncio.gather(task1, task2, return_exceptions=True)
+
+    asyncio.run(scenario())
+
+
+def test_submit_drawing_task_respects_session_limit() -> None:
+    async def scenario() -> None:
+        task_manager = DrawingTaskManager()
+        tool = BigBananaImageGenerationTool()
+
+        plugin = SimpleNamespace(
+            task_manager=task_manager,
+            llm_tools_config=SimpleNamespace(
+                llm_tool_max_tasks_per_session=1,
+                llm_tool_use_background_task=True,
+                llm_tool_direct_send_result=True,
+            ),
+            preference_config=SimpleNamespace(
+                enable_llm_tool_drawing_message=False,
+                drawing_message="drawing...",
+            ),
+            background_callback=SimpleNamespace(enabled=lambda: False),
+            whitelist_guard=SimpleNamespace(check=lambda *a, **k: SimpleNamespace(allowed=True)),
+            cooldown_guard=SimpleNamespace(check=lambda *a, **k: SimpleNamespace(allowed=True)),
+        )
+
+        event1 = SimpleNamespace(
+            unified_msg_origin="session_A",
+            message_obj=SimpleNamespace(message_id="msg_1"),
+        )
+        event2 = SimpleNamespace(
+            unified_msg_origin="session_A",
+            message_obj=SimpleNamespace(message_id="msg_2"),
+        )
+        event_other = SimpleNamespace(
+            unified_msg_origin="session_B",
+            message_obj=SimpleNamespace(message_id="msg_3"),
+        )
+
+        # Mock _generate_and_send_result to block until signaled
+        started_event = asyncio.Event()
+        release_event = asyncio.Event()
+
+        async def mock_generate(*args, **kwargs):
+            started_event.set()
+            await release_event.wait()
+            return "done"
+
+        tool._generate_and_send_result = mock_generate
+
+        # 1st call in session_A -> starts background task
+        res1 = await tool._submit_drawing_task(plugin, event1, {"prompt": "test1"})
+        assert "后台绘图任务已启动" in res1
+        await started_event.wait()
+        assert task_manager.get_session_llm_task_count("session_A") == 1
+
+        # 2nd call in session_A -> blocked by session limit
+        res2 = await tool._submit_drawing_task(plugin, event2, {"prompt": "test2"})
+        assert "当前会话已有正在执行的图片生成任务" in res2
+        assert "已达会话上限" in res2
+
+        # 3rd call in session_B -> allowed
+        started_event_b = asyncio.Event()
+        async def mock_generate_b(*args, **kwargs):
+            started_event_b.set()
+            await release_event.wait()
+            return "done"
+        
+        tool._generate_and_send_result = mock_generate_b
+        res_b = await tool._submit_drawing_task(plugin, event_other, {"prompt": "test3"})
+        assert "后台绘图任务已启动" in res_b
+        await started_event_b.wait()
+        assert task_manager.get_session_llm_task_count("session_B") == 1
+
+        # Release first task and deterministically wait for cleanup
+        release_event.set()
+        for _ in range(100):
+            if (
+                task_manager.get_session_llm_task_count("session_A") == 0
+                and task_manager.get_session_llm_task_count("session_B") == 0
+            ):
+                break
+            await asyncio.sleep(0.01)
+
+        assert task_manager.get_session_llm_task_count("session_A") == 0
+        assert task_manager.get_session_llm_task_count("session_B") == 0
+
+    asyncio.run(scenario())
+
+
+def test_session_limit_can_be_disabled() -> None:
+    async def scenario() -> None:
+        task_manager = DrawingTaskManager()
+        tool = BigBananaImageGenerationTool()
+
+        plugin = SimpleNamespace(
+            task_manager=task_manager,
+            llm_tools_config=SimpleNamespace(
+                llm_tool_max_tasks_per_session=0,  # 0 means unlimited
+                llm_tool_use_background_task=True,
+                llm_tool_direct_send_result=True,
+            ),
+            preference_config=SimpleNamespace(
+                enable_llm_tool_drawing_message=False,
+                drawing_message="drawing...",
+            ),
+            background_callback=SimpleNamespace(enabled=lambda: False),
+        )
+
+        event1 = SimpleNamespace(
+            unified_msg_origin="session_A",
+            message_obj=SimpleNamespace(message_id="msg_1"),
+        )
+        event2 = SimpleNamespace(
+            unified_msg_origin="session_A",
+            message_obj=SimpleNamespace(message_id="msg_2"),
+        )
+
+        release_event = asyncio.Event()
+
+        async def mock_generate(*args, **kwargs):
+            await release_event.wait()
+            return "done"
+
+        tool._generate_and_send_result = mock_generate
+
+        res1 = await tool._submit_drawing_task(plugin, event1, {"prompt": "test1"})
+        res2 = await tool._submit_drawing_task(plugin, event2, {"prompt": "test2"})
+
+        assert "后台绘图任务已启动" in res1
+        assert "后台绘图任务已启动" in res2
+
+        release_event.set()
+        for _ in range(100):
+            if task_manager.get_session_llm_task_count("session_A") == 0:
+                break
+            await asyncio.sleep(0.01)
+
+        assert task_manager.get_session_llm_task_count("session_A") == 0
+
+    asyncio.run(scenario())


### PR DESCRIPTION
…a generation

## Summary by Sourcery

为 LLM 媒体生成后台任务新增会话级跟踪与可配置的并发限制。

New Features:
- 在绘图任务管理器中引入针对会话的 LLM 工具后台任务跟踪。
- 为每个会话强制执行可配置的 LLM 媒体生成后台任务最大并发数，其中 0 表示不做限制。

Enhancements:
- 扩展 LLM 工具配置，增加默认的会话级后台任务并发限制。
- 确保绘图任务管理器的清理过程包含会话级 LLM 任务状态。

Tests:
- 新增测试，覆盖会话级 LLM 任务跟踪、`cancel_all` 时的清理、会话级并发限制的执行，以及通过配置禁用该限制的场景。
- 更新配置默认值相关测试，将会话级 LLM 后台任务并发限制纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add session-scoped tracking and configurable concurrency limits for LLM media-generation background tasks.

New Features:
- Introduce per-session tracking of LLM tool background tasks in the drawing task manager.
- Enforce a configurable maximum number of concurrent LLM media-generation background tasks per session, with 0 meaning no limit.

Enhancements:
- Extend LLM tools configuration with a default per-session background task concurrency limit.
- Ensure drawing task manager cleanup includes per-session LLM task state.

Tests:
- Add tests covering per-session LLM task tracking, cleanup on cancel_all, enforcement of per-session limits, and disabling of the limit via configuration.
- Update configuration default tests to include the per-session LLM background task limit.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 LLM 媒体生成后台任务新增会话级跟踪与可配置的并发限制。

New Features:
- 在绘图任务管理器中引入针对会话的 LLM 工具后台任务跟踪。
- 为每个会话强制执行可配置的 LLM 媒体生成后台任务最大并发数，其中 0 表示不做限制。

Enhancements:
- 扩展 LLM 工具配置，增加默认的会话级后台任务并发限制。
- 确保绘图任务管理器的清理过程包含会话级 LLM 任务状态。

Tests:
- 新增测试，覆盖会话级 LLM 任务跟踪、`cancel_all` 时的清理、会话级并发限制的执行，以及通过配置禁用该限制的场景。
- 更新配置默认值相关测试，将会话级 LLM 后台任务并发限制纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add session-scoped tracking and configurable concurrency limits for LLM media-generation background tasks.

New Features:
- Introduce per-session tracking of LLM tool background tasks in the drawing task manager.
- Enforce a configurable maximum number of concurrent LLM media-generation background tasks per session, with 0 meaning no limit.

Enhancements:
- Extend LLM tools configuration with a default per-session background task concurrency limit.
- Ensure drawing task manager cleanup includes per-session LLM task state.

Tests:
- Add tests covering per-session LLM task tracking, cleanup on cancel_all, enforcement of per-session limits, and disabling of the limit via configuration.
- Update configuration default tests to include the per-session LLM background task limit.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 LLM 媒体生成后台任务新增会话级跟踪与可配置的并发限制。

New Features:
- 在绘图任务管理器中引入针对会话的 LLM 工具后台任务跟踪。
- 为每个会话强制执行可配置的 LLM 媒体生成后台任务最大并发数，其中 0 表示不做限制。

Enhancements:
- 扩展 LLM 工具配置，增加默认的会话级后台任务并发限制。
- 确保绘图任务管理器的清理过程包含会话级 LLM 任务状态。

Tests:
- 新增测试，覆盖会话级 LLM 任务跟踪、`cancel_all` 时的清理、会话级并发限制的执行，以及通过配置禁用该限制的场景。
- 更新配置默认值相关测试，将会话级 LLM 后台任务并发限制纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add session-scoped tracking and configurable concurrency limits for LLM media-generation background tasks.

New Features:
- Introduce per-session tracking of LLM tool background tasks in the drawing task manager.
- Enforce a configurable maximum number of concurrent LLM media-generation background tasks per session, with 0 meaning no limit.

Enhancements:
- Extend LLM tools configuration with a default per-session background task concurrency limit.
- Ensure drawing task manager cleanup includes per-session LLM task state.

Tests:
- Add tests covering per-session LLM task tracking, cleanup on cancel_all, enforcement of per-session limits, and disabling of the limit via configuration.
- Update configuration default tests to include the per-session LLM background task limit.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 LLM 媒体生成后台任务新增会话级跟踪与可配置的并发限制。

New Features:
- 在绘图任务管理器中引入针对会话的 LLM 工具后台任务跟踪。
- 为每个会话强制执行可配置的 LLM 媒体生成后台任务最大并发数，其中 0 表示不做限制。

Enhancements:
- 扩展 LLM 工具配置，增加默认的会话级后台任务并发限制。
- 确保绘图任务管理器的清理过程包含会话级 LLM 任务状态。

Tests:
- 新增测试，覆盖会话级 LLM 任务跟踪、`cancel_all` 时的清理、会话级并发限制的执行，以及通过配置禁用该限制的场景。
- 更新配置默认值相关测试，将会话级 LLM 后台任务并发限制纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add session-scoped tracking and configurable concurrency limits for LLM media-generation background tasks.

New Features:
- Introduce per-session tracking of LLM tool background tasks in the drawing task manager.
- Enforce a configurable maximum number of concurrent LLM media-generation background tasks per session, with 0 meaning no limit.

Enhancements:
- Extend LLM tools configuration with a default per-session background task concurrency limit.
- Ensure drawing task manager cleanup includes per-session LLM task state.

Tests:
- Add tests covering per-session LLM task tracking, cleanup on cancel_all, enforcement of per-session limits, and disabling of the limit via configuration.
- Update configuration default tests to include the per-session LLM background task limit.

</details>

</details>

</details>

新功能：
- 在绘图任务管理器中按会话跟踪 LLM 工具后台任务，并对媒体生成工具强制执行可配置的按会话并发限制。

增强：
- 添加一个可配置的“每个会话允许的最大并发 LLM 工具后台任务数”，其中 0 表示不设上限。
- 将默认的 LLM 工具和视频工具预设名称改为非空标识符，并使配置模式（schema）和测试与这些默认值保持一致。

测试：
- 添加单元测试，用于覆盖基于会话的 LLM 任务跟踪、按会话限制的执行与禁用，以及 LLM 工具配置中更新后的默认预设名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 LLM 媒体生成后台任务新增会话级跟踪与可配置的并发限制。

New Features:
- 在绘图任务管理器中引入针对会话的 LLM 工具后台任务跟踪。
- 为每个会话强制执行可配置的 LLM 媒体生成后台任务最大并发数，其中 0 表示不做限制。

Enhancements:
- 扩展 LLM 工具配置，增加默认的会话级后台任务并发限制。
- 确保绘图任务管理器的清理过程包含会话级 LLM 任务状态。

Tests:
- 新增测试，覆盖会话级 LLM 任务跟踪、`cancel_all` 时的清理、会话级并发限制的执行，以及通过配置禁用该限制的场景。
- 更新配置默认值相关测试，将会话级 LLM 后台任务并发限制纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add session-scoped tracking and configurable concurrency limits for LLM media-generation background tasks.

New Features:
- Introduce per-session tracking of LLM tool background tasks in the drawing task manager.
- Enforce a configurable maximum number of concurrent LLM media-generation background tasks per session, with 0 meaning no limit.

Enhancements:
- Extend LLM tools configuration with a default per-session background task concurrency limit.
- Ensure drawing task manager cleanup includes per-session LLM task state.

Tests:
- Add tests covering per-session LLM task tracking, cleanup on cancel_all, enforcement of per-session limits, and disabling of the limit via configuration.
- Update configuration default tests to include the per-session LLM background task limit.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 LLM 媒体生成后台任务新增会话级跟踪与可配置的并发限制。

New Features:
- 在绘图任务管理器中引入针对会话的 LLM 工具后台任务跟踪。
- 为每个会话强制执行可配置的 LLM 媒体生成后台任务最大并发数，其中 0 表示不做限制。

Enhancements:
- 扩展 LLM 工具配置，增加默认的会话级后台任务并发限制。
- 确保绘图任务管理器的清理过程包含会话级 LLM 任务状态。

Tests:
- 新增测试，覆盖会话级 LLM 任务跟踪、`cancel_all` 时的清理、会话级并发限制的执行，以及通过配置禁用该限制的场景。
- 更新配置默认值相关测试，将会话级 LLM 后台任务并发限制纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add session-scoped tracking and configurable concurrency limits for LLM media-generation background tasks.

New Features:
- Introduce per-session tracking of LLM tool background tasks in the drawing task manager.
- Enforce a configurable maximum number of concurrent LLM media-generation background tasks per session, with 0 meaning no limit.

Enhancements:
- Extend LLM tools configuration with a default per-session background task concurrency limit.
- Ensure drawing task manager cleanup includes per-session LLM task state.

Tests:
- Add tests covering per-session LLM task tracking, cleanup on cancel_all, enforcement of per-session limits, and disabling of the limit via configuration.
- Update configuration default tests to include the per-session LLM background task limit.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 LLM 媒体生成后台任务新增会话级跟踪与可配置的并发限制。

New Features:
- 在绘图任务管理器中引入针对会话的 LLM 工具后台任务跟踪。
- 为每个会话强制执行可配置的 LLM 媒体生成后台任务最大并发数，其中 0 表示不做限制。

Enhancements:
- 扩展 LLM 工具配置，增加默认的会话级后台任务并发限制。
- 确保绘图任务管理器的清理过程包含会话级 LLM 任务状态。

Tests:
- 新增测试，覆盖会话级 LLM 任务跟踪、`cancel_all` 时的清理、会话级并发限制的执行，以及通过配置禁用该限制的场景。
- 更新配置默认值相关测试，将会话级 LLM 后台任务并发限制纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add session-scoped tracking and configurable concurrency limits for LLM media-generation background tasks.

New Features:
- Introduce per-session tracking of LLM tool background tasks in the drawing task manager.
- Enforce a configurable maximum number of concurrent LLM media-generation background tasks per session, with 0 meaning no limit.

Enhancements:
- Extend LLM tools configuration with a default per-session background task concurrency limit.
- Ensure drawing task manager cleanup includes per-session LLM task state.

Tests:
- Add tests covering per-session LLM task tracking, cleanup on cancel_all, enforcement of per-session limits, and disabling of the limit via configuration.
- Update configuration default tests to include the per-session LLM background task limit.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 LLM 媒体生成后台任务新增会话级跟踪与可配置的并发限制。

New Features:
- 在绘图任务管理器中引入针对会话的 LLM 工具后台任务跟踪。
- 为每个会话强制执行可配置的 LLM 媒体生成后台任务最大并发数，其中 0 表示不做限制。

Enhancements:
- 扩展 LLM 工具配置，增加默认的会话级后台任务并发限制。
- 确保绘图任务管理器的清理过程包含会话级 LLM 任务状态。

Tests:
- 新增测试，覆盖会话级 LLM 任务跟踪、`cancel_all` 时的清理、会话级并发限制的执行，以及通过配置禁用该限制的场景。
- 更新配置默认值相关测试，将会话级 LLM 后台任务并发限制纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add session-scoped tracking and configurable concurrency limits for LLM media-generation background tasks.

New Features:
- Introduce per-session tracking of LLM tool background tasks in the drawing task manager.
- Enforce a configurable maximum number of concurrent LLM media-generation background tasks per session, with 0 meaning no limit.

Enhancements:
- Extend LLM tools configuration with a default per-session background task concurrency limit.
- Ensure drawing task manager cleanup includes per-session LLM task state.

Tests:
- Add tests covering per-session LLM task tracking, cleanup on cancel_all, enforcement of per-session limits, and disabling of the limit via configuration.
- Update configuration default tests to include the per-session LLM background task limit.

</details>

</details>

</details>

</details>