### PR TITLE
fix(providers): omit n=1 in FormData for OpenAI Images edits to fix proxy form validation

### DIFF
--- a/core/providers/openai_images.py
+++ b/core/providers/openai_images.py
@@ -43,6 +43,9 @@ class OpenAIImagesProvider(StandardProvider):
         multipart = FormData()
         for key, val in data.items():
             if val is not None:
+                # 在 multipart 表单中，如果 n 为 1 或默认值，省略该字段以避免部分中转站校验 FormData 字符串 "1" 报错
+                if key == "n" and (val == 1 or val == "1"):
+                    continue
                 multipart.add_field(name=key, value=str(val))
         for index, image in enumerate(self.image_list, start=1):
             file_mime = image.mime.replace("image/jpg", "image/jpeg")


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 当图像编辑的 multipart 请求中 `n` 字段的值为 1 时，跳过发送该字段，以防止代理在表单验证时出现错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Skip sending the `n` field in image edit multipart requests when its value is 1 to prevent proxy form validation errors.

</details>