### PR TITLE
fix: 确保 event 缺失 message_obj 时的安全性并优化后台回调与图片组件构建

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1191,6 +1191,18 @@
                 "type": "int",
                 "default": 120,
                 "hint": "发送消息后等待用户发送图片或触发结束命令的最大时间（秒），每次收集后重置剩余时间。"
+            },
+            "quote_reply_mode": {
+                "description": "回复引用配置",
+                "type": "string",
+                "options": [
+                    "both",
+                    "command_only",
+                    "tool_only",
+                    "none"
+                ],
+                "default": "both",
+                "hint": "设置响应消息是否引用回复用户的触发消息。both：命令和 LLM 工具均引用回复（默认）；command_only：仅命令引用回复；tool_only：仅 LLM 工具引用回复；none：不引用回复。"
             }
         }
     },

--- a/core/commands/drawing/handler.py
+++ b/core/commands/drawing/handler.py
@@ -7,7 +7,12 @@ import astrbot.api.message_components as Comp
 from astrbot.api import logger
 from astrbot.core.message.message_event_result import MessageChain
 
-from ...drawing import DrawingPipeline, ImageSaver, parse_params
+from ...drawing import (
+    DrawingPipeline,
+    ImageSaver,
+    parse_params,
+)
+from ...utils import build_message_chain, build_result_message_chain
 from ...drawing.collector import ImageCollector
 from ...schemas import MAX_SIZE_B64_LEN, GenerationResult
 from .gather_session import DrawingGatherSession
@@ -59,10 +64,12 @@ class DrawingCommandHandler:
         if not cooldown_check.allowed:
             logger.info(cooldown_check.log_message)
             yield event.chain_result(
-                [
-                    Comp.Reply(id=event.message_obj.message_id),
+                build_message_chain(
+                    event,
                     Comp.Plain(f"❌ {cooldown_check.message}"),
-                ]
+                    quote_reply_mode=self.plugin.preference_config.quote_reply_mode,
+                    is_command=True,
+                )
             )
             return
 
@@ -119,12 +126,14 @@ class DrawingCommandHandler:
             await image_collector.supplement_avatars()
         if not image_collector.check_images_limit():
             yield event.chain_result(
-                [
-                    Comp.Reply(id=event.message_obj.message_id),
+                build_message_chain(
+                    event,
                     Comp.Plain(
                         f"❌ 图片数量不足，当前仅 {len(image_collector.images)} 张，最少需要 {image_collector.min_images} 张"
                     ),
-                ]
+                    quote_reply_mode=self.plugin.preference_config.quote_reply_mode,
+                    is_command=True,
+                )
             )
             return
 
@@ -233,19 +242,25 @@ class DrawingCommandHandler:
                     == "video_generation"
                     else "图片"
                 )
-                msg_chain: list[BaseMessageComponent] = [
-                    Comp.Reply(id=event.message_obj.message_id),
+                msg_chain = build_message_chain(
+                    event,
                     Comp.Plain(f"❌ {media_name}生成失败：{result.error_message}"),
-                ]
+                    quote_reply_mode=self.plugin.preference_config.quote_reply_mode,
+                    is_command=True,
+                )
             else:
                 # 成功，标记冷却时间
                 self.plugin.cooldown_guard.mark_cooldown(event.get_group_id())
                 # 构建消息链
-                msg_chain = self._build_result_message_chain(
+                msg_chain = build_result_message_chain(
                     event,
                     result=result,
                     url_only=params.get("url", self.plugin.params_config.url),
+                    quote_reply_mode=self.plugin.preference_config.quote_reply_mode,
+                    is_command=True,
                     temporary_paths=temporary_paths,
+                    image_saver=self.image_saver,
+                    temp_dir=self.plugin.temp_dir,
                 )
 
             # 包装消息链类型
@@ -291,69 +306,6 @@ class DrawingCommandHandler:
         )
         prompt = prompt.rstrip()
         return f"{prompt}\n\n{at_avatar_note}" if prompt else at_avatar_note
-
-    def _build_result_message_chain(
-        self,
-        event: AstrMessageEvent,
-        result: GenerationResult,
-        url_only: bool = False,
-        temporary_paths: list[Path] | None = None,
-    ) -> list[BaseMessageComponent]:
-        """构造适配平台限制的绘图结果消息链。
-
-        Args:
-            event: 当前绘图任务的消息事件。
-            result: 图片生成结果。
-            url_only: 是否只发送图片 URL。
-            temporary_paths: 用于记录本次任务创建的临时文件。
-
-        Returns:
-            可直接发送到消息平台的消息组件列表。
-        """
-        msg_chain: list[BaseMessageComponent] = [
-            Comp.Reply(id=event.message_obj.message_id)
-        ]
-        result_urls = [url for url in result.urls if url is not None]
-        video_urls = [video.url for video in result.videos if video.url]
-        # 如果仅url，这里尝试检查有无url，无则报错
-        if url_only:
-            urls = video_urls or result_urls
-            if urls:
-                msg_chain.append(Comp.Plain("\n".join(urls)))
-            else:
-                msg_chain.append(Comp.Plain("❌ 生成失败：没有可用的媒体 URL"))
-            return msg_chain
-
-        if video_urls:
-            msg_chain.extend(Comp.Video.fromURL(url) for url in video_urls)
-            return msg_chain
-
-        images_with_bytes = [image for image in result.images if image.bytes]
-        # 对tg做特殊处理
-        if event.platform_meta.name == "telegram" and any(
-            (image.base64 and len(image.base64) > MAX_SIZE_B64_LEN)
-            for image in images_with_bytes
-        ):
-            save_results = self.image_saver.save_images_to_local(
-                images_with_bytes, self.plugin.temp_dir
-            )
-            if temporary_paths is not None:
-                temporary_paths.extend(path for _name, path in save_results)
-            for name_, path_ in save_results:
-                msg_chain.append(Comp.File(name=name_, file=str(path_)))
-            return msg_chain
-
-        # 其他平台目前默认不特殊处理图片大小限制
-        if images_with_bytes:
-            msg_chain.extend(
-                Comp.Image.fromBase64(image.base64) for image in images_with_bytes
-            )
-        # 只有urls，那么应该是下载失败了，直接发送url吧
-        elif result_urls:
-            msg_chain.append(Comp.Plain("\n".join(result_urls)))
-        else:
-            msg_chain.append(Comp.Plain("❌ 图片生成失败：响应中未包含图片数据"))
-        return msg_chain
 
     async def _build_start_msg(
         self, event: AstrMessageEvent, text: str

--- a/core/drawing/__init__.py
+++ b/core/drawing/__init__.py
@@ -19,3 +19,4 @@ __all__ = [
     "ImageSaver",
     "parse_params",
 ]
+

--- a/core/drawing/collector.py
+++ b/core/drawing/collector.py
@@ -12,6 +12,7 @@ from astrbot.api.star import StarTools
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 
 from ..schemas import SUPPORTED_FILE_FORMATS_WITH_DOT
+from ..utils import get_message_id
 from .mention_utils import QQ_OFFICIAL_MENTION_RE, get_qq_official_mention_names
 
 if TYPE_CHECKING:
@@ -105,7 +106,7 @@ class ImageCollector:
         if event is None:
             event = self.event
         # 防止同一个 event 重复操作
-        event_id = event.message_obj.message_id
+        event_id = get_message_id(event) or f"event-{id(event)}"
         if event_id in self._processed_events:
             logger.info(f"[BIG BANANA] event {event_id} 已处理过，跳过收集图片")
             return

--- a/core/drawing/tasks.py
+++ b/core/drawing/tasks.py
@@ -7,6 +7,9 @@ if TYPE_CHECKING:
     from astrbot.api.event import AstrMessageEvent
 
 
+from ..utils import get_message_id
+
+
 class DrawingTaskManager:
     """跟踪绘图任务。"""
 
@@ -26,8 +29,7 @@ class DrawingTaskManager:
         Returns:
             可在不同平台和会话之间安全区分的任务键。
         """
-        message_obj = getattr(event, "message_obj", None)
-        message_id = getattr(message_obj, "message_id", None)
+        message_id = get_message_id(event)
         if message_id is None:
             # LLM 工具调用等场景可能只有虚拟事件，没有对应的原始消息对象。
             # 使用事件对象身份作为回退值，既避免属性错误，也不会让同一会话中的

--- a/core/llm_tools/media_generation_base.py
+++ b/core/llm_tools/media_generation_base.py
@@ -13,6 +13,7 @@ from astrbot.core.message.message_event_result import MessageChain
 
 from ..drawing.collector import ImageCollector
 from ..schemas import GenerationResult
+from ..utils import build_message_chain, build_result_message_chain
 
 if TYPE_CHECKING:
     from astrbot.core.agent.tool import ToolExecResult
@@ -72,10 +73,12 @@ class BaseMediaGenerationTool(FunctionTool[AstrAgentContext], ABC):
                     else plugin.preference_config.drawing_message
                 ).strip()
                 if drawing_message:
-                    drawing_chain: list[BaseMessageComponent] = [
-                        Comp.Reply(id=event.message_obj.message_id),
+                    drawing_chain = build_message_chain(
+                        event,
                         Comp.Plain(drawing_message),
-                    ]
+                        quote_reply_mode=plugin.preference_config.quote_reply_mode,
+                        is_command=False,
+                    )
                     await event.send(event.chain_result(drawing_chain))
 
             if is_background_task and (use_background_callback or direct_send_result):
@@ -147,10 +150,7 @@ class BaseMediaGenerationTool(FunctionTool[AstrAgentContext], ABC):
             if not result.error_message:
                 plugin.cooldown_guard.mark_cooldown(event.get_group_id())
 
-            if not direct_send_result:
-                if not use_background_callback:
-                    return self._build_model_tool_result(result)
-
+            if use_background_callback:
                 handled = await plugin.background_callback.dispatch(
                     event=event,
                     result=self._build_callback_result_chain(result),
@@ -161,27 +161,18 @@ class BaseMediaGenerationTool(FunctionTool[AstrAgentContext], ABC):
                 if handled:
                     return None
 
-            completion_text = await self._send_generation_result(
-                plugin,
-                event,
-                result,
-                params,
-                use_proactive_send=is_background_task
-                and (plugin.preference_config.background_task_send_type == "active"),
-                temporary_paths=temporary_paths,
-            )
-
-            if use_background_callback and direct_send_result:
-                handled = await plugin.background_callback.dispatch(
-                    event=event,
-                    result=self._build_callback_result_chain(completion_text),
-                    params=params,
-                    unified_msg_origin=unified_msg_origin,
-                    is_success=not result.error_message,
+            if direct_send_result:
+                return await self._send_generation_result(
+                    plugin,
+                    event,
+                    result,
+                    params,
+                    use_proactive_send=is_background_task
+                    and (plugin.preference_config.background_task_send_type == "active"),
+                    temporary_paths=temporary_paths,
                 )
-                if handled:
-                    return None
-            return completion_text
+
+            return self._build_model_tool_result(result)
         finally:
             if is_background_task:
                 plugin.task_manager.finish(plugin.task_manager.build_task_id(event))
@@ -205,16 +196,22 @@ class BaseMediaGenerationTool(FunctionTool[AstrAgentContext], ABC):
     ) -> str:
         try:
             if result.error_message:
-                msg_chain: list[BaseMessageComponent] = [
-                    Comp.Reply(id=event.message_obj.message_id),
+                msg_chain = build_message_chain(
+                    event,
                     Comp.Plain(f"❌ {self.media_name}生成失败：{result.error_message}"),
-                ]
+                    quote_reply_mode=plugin.preference_config.quote_reply_mode,
+                    is_command=False,
+                )
             else:
-                msg_chain = plugin.drawing_command_handler._build_result_message_chain(
+                msg_chain = build_result_message_chain(
                     event,
                     result=result,
                     url_only=params.get("url", plugin.params_config.url),
+                    quote_reply_mode=plugin.preference_config.quote_reply_mode,
+                    is_command=False,
                     temporary_paths=temporary_paths,
+                    image_saver=plugin.image_saver,
+                    temp_dir=plugin.temp_dir,
                 )
 
             if use_proactive_send:

--- a/core/schemas/common.py
+++ b/core/schemas/common.py
@@ -49,6 +49,9 @@ class PreferenceConfig:
     """ 后台任务消息发送方式。event：事件消息（被动消息，默认）；active：主动消息 """
     gather_timeout: int = 120
     """ 收集模式超时时间, 单位: 秒 """
+    quote_reply_mode: str = "both"
+    """ 回复引用配置。both: 命令和LLM工具均引用回复；command_only: 仅命令引用回复；tool_only: 仅LLM工具引用回复；none: 不引用回复 """
+
 
 
 @dataclass(repr=False, slots=True)

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,0 +1,13 @@
+from .event_utils import (
+    build_message_chain,
+    build_reply_component,
+    build_result_message_chain,
+    get_message_id,
+)
+
+__all__ = [
+    "get_message_id",
+    "build_reply_component",
+    "build_message_chain",
+    "build_result_message_chain",
+]

--- a/core/utils/event_utils.py
+++ b/core/utils/event_utils.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import astrbot.api.message_components as Comp
+
+from ..schemas import MAX_SIZE_B64_LEN, GenerationResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from astrbot.api.event import AstrMessageEvent
+    from astrbot.core.message.components import BaseMessageComponent
+
+    from ..drawing.saver import ImageSaver
+
+
+def get_message_id(event: AstrMessageEvent) -> str | None:
+    """安全获取事件关联的消息 ID，若不存在或不是有效 message_obj 则返回 None。"""
+    message_obj = getattr(event, "message_obj", None)
+    if message_obj is None:
+        return None
+    message_id = getattr(message_obj, "message_id", None)
+    if message_id is None:
+        return None
+    id_str = str(message_id).strip()
+    return id_str if id_str != "" else None
+
+
+def build_reply_component(
+    event: AstrMessageEvent,
+    quote_reply_mode: str = "both",
+    is_command: bool = True,
+) -> BaseMessageComponent | None:
+    """若满足配置的回复引用条件且事件中包含有效 message_id，则构造 Reply 引用组件，否则返回 None。"""
+    if quote_reply_mode == "none":
+        return None
+    if is_command and quote_reply_mode == "tool_only":
+        return None
+    if not is_command and quote_reply_mode == "command_only":
+        return None
+
+    message_id = get_message_id(event)
+    if message_id is not None:
+        return Comp.Reply(id=message_id)
+    return None
+
+
+def build_message_chain(
+    event: AstrMessageEvent,
+    components: BaseMessageComponent | list[BaseMessageComponent] | None = None,
+    quote_reply_mode: str = "both",
+    is_command: bool = True,
+) -> list[BaseMessageComponent]:
+    """构造包含可选 Reply 引用和目标组件的完整消息组件列表。"""
+    chain: list[BaseMessageComponent] = []
+    if reply := build_reply_component(
+        event, quote_reply_mode=quote_reply_mode, is_command=is_command
+    ):
+        chain.append(reply)
+    if components is not None:
+        if isinstance(components, list):
+            chain.extend(components)
+        else:
+            chain.append(components)
+    return chain
+
+
+def build_result_message_chain(
+    event: AstrMessageEvent,
+    result: GenerationResult,
+    url_only: bool = False,
+    quote_reply_mode: str = "both",
+    is_command: bool = True,
+    temporary_paths: list[Path] | None = None,
+    image_saver: ImageSaver | None = None,
+    temp_dir: Path | str | None = None,
+) -> list[BaseMessageComponent]:
+    """构造适配平台限制的媒体生成结果消息链。"""
+    msg_chain = build_message_chain(
+        event,
+        components=None,
+        quote_reply_mode=quote_reply_mode,
+        is_command=is_command,
+    )
+    result_urls = [url for url in result.urls if url is not None]
+    video_urls = [video.url for video in result.videos if video.url]
+
+    # 如果仅 url，这里尝试检查有无 url，无则报错
+    if url_only:
+        urls = video_urls or result_urls
+        if urls:
+            msg_chain.append(Comp.Plain("\n".join(urls)))
+        else:
+            msg_chain.append(Comp.Plain("❌ 生成失败：没有可用的媒体 URL"))
+        return msg_chain
+
+    if video_urls:
+        msg_chain.extend(Comp.Video.fromURL(url) for url in video_urls)
+        return msg_chain
+
+    images_with_bytes = [image for image in result.images if image.bytes]
+    # 对 telegram 做特殊处理
+    platform_meta = getattr(event, "platform_meta", None)
+    platform_name = getattr(platform_meta, "name", None) if platform_meta else None
+    if platform_name == "telegram" and any(
+        (image.base64 and len(image.base64) > MAX_SIZE_B64_LEN)
+        for image in images_with_bytes
+    ):
+        if image_saver is not None and temp_dir is not None:
+            save_results = image_saver.save_images_to_local(images_with_bytes, temp_dir)
+            if temporary_paths is not None:
+                temporary_paths.extend(path for _name, path in save_results)
+            for name_, path_ in save_results:
+                msg_chain.append(Comp.File(name=name_, file=str(path_)))
+            return msg_chain
+
+    # 其他平台目前默认不特殊处理图片大小限制
+    if images_with_bytes:
+        msg_chain.extend(
+            Comp.Image.fromBase64(image.base64) for image in images_with_bytes
+        )
+    elif result_urls:
+        msg_chain.append(Comp.Plain("\n".join(result_urls)))
+    else:
+        msg_chain.append(Comp.Plain("❌ 图片生成失败：响应中未包含图片数据"))
+    return msg_chain

--- a/tests/test_background_callback.py
+++ b/tests/test_background_callback.py
@@ -95,3 +95,5 @@ def test_callback_receives_captured_origin_instead_of_current_event_value() -> N
     assert handled is True
     assert received["event"] is event
     assert received["unified_msg_origin"] == "original:session"
+
+

--- a/tests/test_image_generation_tool.py
+++ b/tests/test_image_generation_tool.py
@@ -111,3 +111,93 @@ def test_llm_image_tool_does_not_append_command_avatar_note() -> None:
 
     pipeline_run.assert_awaited_once()
     assert params["prompt"] == "portrait"
+
+
+def test_callback_receives_image_chain_even_when_direct_send_is_true() -> None:
+    import astrbot.api.message_components as Comp
+
+    dispatch_mock = AsyncMock(return_value=True)
+    plugin = SimpleNamespace(
+        cooldown_guard=SimpleNamespace(mark_cooldown=lambda gid: None),
+        background_callback=SimpleNamespace(dispatch=dispatch_mock),
+        task_manager=SimpleNamespace(
+            finish=lambda tid: None, build_task_id=lambda evt: "task-1"
+        ),
+    )
+    tool = BigBananaImageGenerationTool()
+
+    gen_result = GenerationResult(
+        images=[ImageResource("image/png", b"data", "b64data")]
+    )
+
+    with patch.object(tool, "_generate_result", new=AsyncMock(return_value=gen_result)):
+        res = asyncio.run(
+            tool._generate_and_send_result(
+                plugin=plugin,
+                event=SimpleNamespace(
+                    unified_msg_origin="origin",
+                    get_group_id=lambda: "g1",
+                    platform_meta=SimpleNamespace(name="qq"),
+                ),
+                params={},
+                image_references=None,
+                unified_msg_origin="origin",
+                is_background_task=True,
+                use_background_callback=True,
+                direct_send_result=True,
+            )
+        )
+
+    assert res is None
+    dispatch_mock.assert_awaited_once()
+    passed_result_chain = dispatch_mock.await_args.kwargs["result"]
+    assert any(isinstance(comp, Comp.Image) for comp in passed_result_chain.chain)
+
+
+def test_background_callback_receives_error_chain_without_image_components() -> None:
+    import astrbot.api.message_components as Comp
+
+    dispatch_mock = AsyncMock(return_value=True)
+    plugin = SimpleNamespace(
+        cooldown_guard=SimpleNamespace(mark_cooldown=lambda gid: None),
+        background_callback=SimpleNamespace(dispatch=dispatch_mock),
+        task_manager=SimpleNamespace(
+            finish=lambda tid: None, build_task_id=lambda evt: "task-error-1"
+        ),
+    )
+    tool = BigBananaImageGenerationTool()
+
+    error_result = GenerationResult(
+        images=[],
+        urls=[],
+        error_message="image generation failed",
+    )
+
+    with patch.object(tool, "_generate_result", new=AsyncMock(return_value=error_result)):
+        res = asyncio.run(
+            tool._generate_and_send_result(
+                plugin=plugin,
+                event=SimpleNamespace(
+                    unified_msg_origin="origin",
+                    get_group_id=lambda: "g1",
+                    platform_meta=SimpleNamespace(name="qq"),
+                ),
+                params={},
+                image_references=None,
+                unified_msg_origin="origin",
+                is_background_task=True,
+                use_background_callback=True,
+                direct_send_result=True,
+            )
+        )
+
+    assert res is None
+    dispatch_mock.assert_awaited_once()
+    passed_result_chain = dispatch_mock.await_args.kwargs["result"]
+    assert any(
+        isinstance(comp, Comp.Plain) and "image generation failed" in comp.text
+        for comp in passed_result_chain.chain
+    )
+    assert not any(isinstance(comp, Comp.Image) for comp in passed_result_chain.chain)
+
+

--- a/tests/test_mock_event_message_obj.py
+++ b/tests/test_mock_event_message_obj.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import astrbot.api.message_components as Comp
+
+from core.commands.drawing.handler import DrawingCommandHandler
+from core.schemas import GenerationResult, ImageResource
+from core.utils import (
+    build_message_chain,
+    build_reply_component,
+    build_result_message_chain,
+    get_message_id,
+)
+
+
+def test_get_message_id_and_build_reply_with_valid_event() -> None:
+    event = SimpleNamespace(message_obj=SimpleNamespace(message_id="msg_123"))
+    assert get_message_id(event) == "msg_123"
+    reply = build_reply_component(event)
+    assert reply is not None
+    assert reply.id == "msg_123"
+
+
+def test_get_message_id_and_build_reply_without_message_obj() -> None:
+    event = SimpleNamespace()
+    assert get_message_id(event) is None
+    assert build_reply_component(event) is None
+
+
+def test_get_message_id_with_non_string_message_id() -> None:
+    event = SimpleNamespace(message_obj=SimpleNamespace(message_id=12345))
+    assert get_message_id(event) == "12345"
+
+
+def test_get_message_id_with_zero_id() -> None:
+    event = SimpleNamespace(message_obj=SimpleNamespace(message_id=0))
+    assert get_message_id(event) == "0"
+    reply = build_reply_component(event)
+    assert reply is not None
+    assert reply.id == "0"
+
+
+def test_get_message_id_and_build_reply_with_mock_raising_attribute_error() -> None:
+    # 模拟 Mock 对象，访问 message_obj 显式抛出 AttributeError
+    mock_event = Mock(spec=["unified_msg_origin", "platform_meta"])
+    assert get_message_id(mock_event) is None
+    assert build_reply_component(mock_event) is None
+
+
+def test_build_result_message_chain_without_message_obj() -> None:
+    mock_event = Mock(spec=["unified_msg_origin", "platform_meta"])
+    mock_event.platform_meta = SimpleNamespace(name="qq")
+
+    result = GenerationResult(images=[SimpleNamespace(bytes=b"dummy", base64=None)])
+    chain = build_result_message_chain(mock_event, result, quote_reply_mode="both")
+
+    # 校验结果消息链中不包含 Comp.Reply
+    assert not any(isinstance(comp, Comp.Reply) for comp in chain)
+
+
+def test_quote_reply_mode_options() -> None:
+    event = SimpleNamespace(message_obj=SimpleNamespace(message_id="msg_123"))
+
+    # both
+    assert build_reply_component(event, quote_reply_mode="both", is_command=True) is not None
+    assert build_reply_component(event, quote_reply_mode="both", is_command=False) is not None
+
+    # command_only
+    assert build_reply_component(event, quote_reply_mode="command_only", is_command=True) is not None
+    assert build_reply_component(event, quote_reply_mode="command_only", is_command=False) is None
+
+    # tool_only
+    assert build_reply_component(event, quote_reply_mode="tool_only", is_command=True) is None
+    assert build_reply_component(event, quote_reply_mode="tool_only", is_command=False) is not None
+
+    # none
+    assert build_reply_component(event, quote_reply_mode="none", is_command=True) is None
+    assert build_reply_component(event, quote_reply_mode="none", is_command=False) is None
+
+
+def test_build_message_chain_helper() -> None:
+    event = SimpleNamespace(message_obj=SimpleNamespace(message_id="msg_123"))
+
+    chain = build_message_chain(event, Comp.Plain("hello"), quote_reply_mode="both", is_command=True)
+    assert len(chain) == 2
+    assert isinstance(chain[0], Comp.Reply)
+    assert chain[0].id == "msg_123"
+    assert isinstance(chain[1], Comp.Plain)
+
+    chain_none = build_message_chain(event, Comp.Plain("hello"), quote_reply_mode="none", is_command=True)
+    assert len(chain_none) == 1
+    assert isinstance(chain_none[0], Comp.Plain)
+
+
+
+


### PR DESCRIPTION
- 修复 event 缺失 message_obj 时构建回复消息引发的 AttributeError
- 确保传递给第三方回调插件的 event 对象在缺失 message_obj 时安全返回 None
- 修复后台回调触发时直接发送参数导致回调缺少图片组件的问题
- 优化回调与结果构建逻辑，清理系统提示词并优先使用最可靠的图片组件格式

## Summary by Sourcery

在消息对象缺失的情况下加强事件处理和后台媒体工作流，同时引入用于安全回复和图片组件构建的共享工具，并使回调行为更加一致。

Bug Fixes:
- 防止在底层事件没有 `message_obj` 时访问 `event.message_obj` 或在绘图和回调流程中构建回复链导致 `AttributeError`。
- 确保在 `raw_message` 或 `message_obj` 不可用时，QQ @提及名称提取返回空映射，而不是抛出错误。
- 保证后台回调在生成失败时只接收仅包含错误的消息链（不包含多余的图片组件），并确保直接发送的后台任务在成功时仍会将图片组件传递给回调。

Enhancements:
- 添加共享的事件工具，用于安全获取消息 ID、根据可配置的引用回复模式构建回复组件，以及从 URL、文件系统路径、Base64 数据或回退内容构建健壮的图片组件。
- 更新绘图处理器、收集器、任务跟踪和 LLM 媒体工具，使其依赖新的安全消息 ID 和回复/图片辅助函数，从而改善在非消息驱动和模拟事件场景下的行为。
- 优化后台结果分发逻辑，使直接发送与回调之间的交互更可预测，并为失败的媒体生成任务提供更精简、更清晰的错误消息。
- 引入可配置的 `quote_reply_mode` 偏好，用于控制命令和工具在发送消息时何时包含回复引用。

Tests:
- 添加测试，用于覆盖在多种事件和数据条件下的安全消息 ID 获取、回复构建和图片组件构建，包括没有 `message_obj` 的事件以及会触发 `AttributeError` 的模拟对象。
- 添加测试，确保在启用 `direct_send_result` 时后台回调能接收包含图片的消息链，而在生成失败时只接收文本错误消息链。
- 扩展关于后台回调行为和基于配置的回复引用的测试，以验证新的事件工具和回调结果消息链语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden event handling and background media workflows when message objects are missing, while introducing shared utilities for safe reply and image component construction and making callback behavior more consistent.

Bug Fixes:
- Prevent AttributeError when accessing event.message_obj or building reply chains in drawing and callback flows where the underlying event has no message_obj.
- Ensure QQ mention name extraction returns an empty mapping instead of failing when raw_message or message_obj are unavailable.
- Guarantee background callbacks receive appropriate error-only chains without stray image components when generation fails, and that direct-send background tasks still pass image components to callbacks.

Enhancements:
- Add shared event utilities for safely obtaining message IDs, building reply components based on configurable quote-reply modes, and constructing robust image components from URLs, filesystem paths, Base64 data, or fallbacks.
- Update drawing handlers, collectors, task tracking, and LLM media tools to rely on the new safe message ID and reply/image helpers, improving behavior in non message-driven and mocked event scenarios.
- Refine background result dispatch logic so direct sending and callbacks interact more predictably, with simplified and clearer error messaging for failed media generation tasks.
- Introduce a configurable quote_reply_mode preference that controls when commands and tools include reply references in outgoing messages.

Tests:
- Add tests covering safe message ID retrieval, reply construction, and image component building under various event and data conditions, including events without message_obj or with AttributeError-raising mocks.
- Add tests ensuring background callbacks receive image chains when direct_send_result is enabled and only text error chains when generation fails.
- Extend tests for background callback behavior and configuration-driven reply quoting to validate the new event utility and callback result-chain semantics.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在消息对象缺失的情况下加强事件处理和后台媒体工作流，同时引入用于安全回复和图片组件构建的共享工具，并使回调行为更加一致。

Bug Fixes:
- 防止在底层事件没有 `message_obj` 时访问 `event.message_obj` 或在绘图和回调流程中构建回复链导致 `AttributeError`。
- 确保在 `raw_message` 或 `message_obj` 不可用时，QQ @提及名称提取返回空映射，而不是抛出错误。
- 保证后台回调在生成失败时只接收仅包含错误的消息链（不包含多余的图片组件），并确保直接发送的后台任务在成功时仍会将图片组件传递给回调。

Enhancements:
- 添加共享的事件工具，用于安全获取消息 ID、根据可配置的引用回复模式构建回复组件，以及从 URL、文件系统路径、Base64 数据或回退内容构建健壮的图片组件。
- 更新绘图处理器、收集器、任务跟踪和 LLM 媒体工具，使其依赖新的安全消息 ID 和回复/图片辅助函数，从而改善在非消息驱动和模拟事件场景下的行为。
- 优化后台结果分发逻辑，使直接发送与回调之间的交互更可预测，并为失败的媒体生成任务提供更精简、更清晰的错误消息。
- 引入可配置的 `quote_reply_mode` 偏好，用于控制命令和工具在发送消息时何时包含回复引用。

Tests:
- 添加测试，用于覆盖在多种事件和数据条件下的安全消息 ID 获取、回复构建和图片组件构建，包括没有 `message_obj` 的事件以及会触发 `AttributeError` 的模拟对象。
- 添加测试，确保在启用 `direct_send_result` 时后台回调能接收包含图片的消息链，而在生成失败时只接收文本错误消息链。
- 扩展关于后台回调行为和基于配置的回复引用的测试，以验证新的事件工具和回调结果消息链语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden event handling and background media workflows when message objects are missing, while introducing shared utilities for safe reply and image component construction and making callback behavior more consistent.

Bug Fixes:
- Prevent AttributeError when accessing event.message_obj or building reply chains in drawing and callback flows where the underlying event has no message_obj.
- Ensure QQ mention name extraction returns an empty mapping instead of failing when raw_message or message_obj are unavailable.
- Guarantee background callbacks receive appropriate error-only chains without stray image components when generation fails, and that direct-send background tasks still pass image components to callbacks.

Enhancements:
- Add shared event utilities for safely obtaining message IDs, building reply components based on configurable quote-reply modes, and constructing robust image components from URLs, filesystem paths, Base64 data, or fallbacks.
- Update drawing handlers, collectors, task tracking, and LLM media tools to rely on the new safe message ID and reply/image helpers, improving behavior in non message-driven and mocked event scenarios.
- Refine background result dispatch logic so direct sending and callbacks interact more predictably, with simplified and clearer error messaging for failed media generation tasks.
- Introduce a configurable quote_reply_mode preference that controls when commands and tools include reply references in outgoing messages.

Tests:
- Add tests covering safe message ID retrieval, reply construction, and image component building under various event and data conditions, including events without message_obj or with AttributeError-raising mocks.
- Add tests ensuring background callbacks receive image chains when direct_send_result is enabled and only text error chains when generation fails.
- Extend tests for background callback behavior and configuration-driven reply quoting to validate the new event utility and callback result-chain semantics.

</details>

</details>

Bug 修复：
- 当在绘图和回调流程中构造回复消息或访问 `event.message_obj` 时，如果 `message_obj` 缺失，避免触发 `AttributeError`。
- 确保后台回调在启用 `direct_send_result` 时仍能收到图像组件，并在 `raw_message` 或 `message_obj` 不存在时，为 QQ @提及名称提取返回安全的空映射。
- 保证第三方回调插件在底层事件不暴露该属性时看到的 `event.message_obj` 为 `None`，而不是抛出错误。

Enhancements:
- 引入共享的事件工具，用于安全获取消息 ID、构建回复组件，以及从 URL、文件路径或 Base64 数据构造图像组件。
- 更新绘图处理器、收集器、任务追踪以及 LLM 媒体工具以使用新的安全事件和消息 ID 辅助方法，从而在非消息驱动场景中提升稳定性。
- 简化后台结果分发逻辑，使直接发送与回调之间的协调更一致，并提供更清晰的失败信息，包括对后台图像生成的错误提示进行精简。

Tests:
- 添加测试，验证在启用 `direct_send_result` 时回调能够收到图像链，并且仅含错误的结果链会省略图像组件。
- 添加测试，确认安全事件封装在第三方回调中将 `message_obj` 暴露为 `None`，包括那些受限或模拟的、会抛出 `AttributeError` 的事件场景。
- 添加测试，覆盖在 `message_obj` 缺失时 `get_message_id`、`build_reply_component`、图像组件构造以及结果链构建的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在消息对象缺失的情况下加强事件处理和后台媒体工作流，同时引入用于安全回复和图片组件构建的共享工具，并使回调行为更加一致。

Bug Fixes:
- 防止在底层事件没有 `message_obj` 时访问 `event.message_obj` 或在绘图和回调流程中构建回复链导致 `AttributeError`。
- 确保在 `raw_message` 或 `message_obj` 不可用时，QQ @提及名称提取返回空映射，而不是抛出错误。
- 保证后台回调在生成失败时只接收仅包含错误的消息链（不包含多余的图片组件），并确保直接发送的后台任务在成功时仍会将图片组件传递给回调。

Enhancements:
- 添加共享的事件工具，用于安全获取消息 ID、根据可配置的引用回复模式构建回复组件，以及从 URL、文件系统路径、Base64 数据或回退内容构建健壮的图片组件。
- 更新绘图处理器、收集器、任务跟踪和 LLM 媒体工具，使其依赖新的安全消息 ID 和回复/图片辅助函数，从而改善在非消息驱动和模拟事件场景下的行为。
- 优化后台结果分发逻辑，使直接发送与回调之间的交互更可预测，并为失败的媒体生成任务提供更精简、更清晰的错误消息。
- 引入可配置的 `quote_reply_mode` 偏好，用于控制命令和工具在发送消息时何时包含回复引用。

Tests:
- 添加测试，用于覆盖在多种事件和数据条件下的安全消息 ID 获取、回复构建和图片组件构建，包括没有 `message_obj` 的事件以及会触发 `AttributeError` 的模拟对象。
- 添加测试，确保在启用 `direct_send_result` 时后台回调能接收包含图片的消息链，而在生成失败时只接收文本错误消息链。
- 扩展关于后台回调行为和基于配置的回复引用的测试，以验证新的事件工具和回调结果消息链语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden event handling and background media workflows when message objects are missing, while introducing shared utilities for safe reply and image component construction and making callback behavior more consistent.

Bug Fixes:
- Prevent AttributeError when accessing event.message_obj or building reply chains in drawing and callback flows where the underlying event has no message_obj.
- Ensure QQ mention name extraction returns an empty mapping instead of failing when raw_message or message_obj are unavailable.
- Guarantee background callbacks receive appropriate error-only chains without stray image components when generation fails, and that direct-send background tasks still pass image components to callbacks.

Enhancements:
- Add shared event utilities for safely obtaining message IDs, building reply components based on configurable quote-reply modes, and constructing robust image components from URLs, filesystem paths, Base64 data, or fallbacks.
- Update drawing handlers, collectors, task tracking, and LLM media tools to rely on the new safe message ID and reply/image helpers, improving behavior in non message-driven and mocked event scenarios.
- Refine background result dispatch logic so direct sending and callbacks interact more predictably, with simplified and clearer error messaging for failed media generation tasks.
- Introduce a configurable quote_reply_mode preference that controls when commands and tools include reply references in outgoing messages.

Tests:
- Add tests covering safe message ID retrieval, reply construction, and image component building under various event and data conditions, including events without message_obj or with AttributeError-raising mocks.
- Add tests ensuring background callbacks receive image chains when direct_send_result is enabled and only text error chains when generation fails.
- Extend tests for background callback behavior and configuration-driven reply quoting to validate the new event utility and callback result-chain semantics.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在消息对象缺失的情况下加强事件处理和后台媒体工作流，同时引入用于安全回复和图片组件构建的共享工具，并使回调行为更加一致。

Bug Fixes:
- 防止在底层事件没有 `message_obj` 时访问 `event.message_obj` 或在绘图和回调流程中构建回复链导致 `AttributeError`。
- 确保在 `raw_message` 或 `message_obj` 不可用时，QQ @提及名称提取返回空映射，而不是抛出错误。
- 保证后台回调在生成失败时只接收仅包含错误的消息链（不包含多余的图片组件），并确保直接发送的后台任务在成功时仍会将图片组件传递给回调。

Enhancements:
- 添加共享的事件工具，用于安全获取消息 ID、根据可配置的引用回复模式构建回复组件，以及从 URL、文件系统路径、Base64 数据或回退内容构建健壮的图片组件。
- 更新绘图处理器、收集器、任务跟踪和 LLM 媒体工具，使其依赖新的安全消息 ID 和回复/图片辅助函数，从而改善在非消息驱动和模拟事件场景下的行为。
- 优化后台结果分发逻辑，使直接发送与回调之间的交互更可预测，并为失败的媒体生成任务提供更精简、更清晰的错误消息。
- 引入可配置的 `quote_reply_mode` 偏好，用于控制命令和工具在发送消息时何时包含回复引用。

Tests:
- 添加测试，用于覆盖在多种事件和数据条件下的安全消息 ID 获取、回复构建和图片组件构建，包括没有 `message_obj` 的事件以及会触发 `AttributeError` 的模拟对象。
- 添加测试，确保在启用 `direct_send_result` 时后台回调能接收包含图片的消息链，而在生成失败时只接收文本错误消息链。
- 扩展关于后台回调行为和基于配置的回复引用的测试，以验证新的事件工具和回调结果消息链语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden event handling and background media workflows when message objects are missing, while introducing shared utilities for safe reply and image component construction and making callback behavior more consistent.

Bug Fixes:
- Prevent AttributeError when accessing event.message_obj or building reply chains in drawing and callback flows where the underlying event has no message_obj.
- Ensure QQ mention name extraction returns an empty mapping instead of failing when raw_message or message_obj are unavailable.
- Guarantee background callbacks receive appropriate error-only chains without stray image components when generation fails, and that direct-send background tasks still pass image components to callbacks.

Enhancements:
- Add shared event utilities for safely obtaining message IDs, building reply components based on configurable quote-reply modes, and constructing robust image components from URLs, filesystem paths, Base64 data, or fallbacks.
- Update drawing handlers, collectors, task tracking, and LLM media tools to rely on the new safe message ID and reply/image helpers, improving behavior in non message-driven and mocked event scenarios.
- Refine background result dispatch logic so direct sending and callbacks interact more predictably, with simplified and clearer error messaging for failed media generation tasks.
- Introduce a configurable quote_reply_mode preference that controls when commands and tools include reply references in outgoing messages.

Tests:
- Add tests covering safe message ID retrieval, reply construction, and image component building under various event and data conditions, including events without message_obj or with AttributeError-raising mocks.
- Add tests ensuring background callbacks receive image chains when direct_send_result is enabled and only text error chains when generation fails.
- Extend tests for background callback behavior and configuration-driven reply quoting to validate the new event utility and callback result-chain semantics.

</details>

</details>

</details>

Bug 修复：
- 在绘图和回调流程中，当底层事件没有 `message_obj` 时，构建回复消息或访问 `event.message_obj` 不再触发 `AttributeError`。
- 在开启 `direct_send_result` 时，仍确保后台回调能够收到图片组件，避免回调处理程序中遗漏图片数据。
- 当 `raw_message` 或 `message_obj` 缺失时，使 QQ @提及名称提取更加健壮，返回空映射而不是抛出错误。

增强：
- 引入共享工具，用于安全获取消息 ID、构建回复组件，以及基于最可靠的可用表示形式（URL、文件路径或 Base64）构建图片组件。
- 更新绘图处理器、LLM 媒体工具、收集器和任务跟踪逻辑，使用新的安全事件与消息 ID 辅助方法，从而提升在非消息驱动场景中的健壮性。
- 简化并强化后台结果分发逻辑，使回调与直接发送的协调更加一致，并为后台任务提供更清晰的失败信息。

测试：
- 新增针对开启 `direct_send_result` 时的回调行为测试，确保图片组件在回调结果链中存在。
- 新增测试，验证安全事件封装在向直接访问 `message_obj` 的第三方回调暴露时，会将其设为 `None`。
- 新增针对真实和模拟事件的 `get_message_id` 与 `build_reply_component` 测试，以及在缺少 `message_obj` 时结果消息链构造的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在消息对象缺失的情况下加强事件处理和后台媒体工作流，同时引入用于安全回复和图片组件构建的共享工具，并使回调行为更加一致。

Bug Fixes:
- 防止在底层事件没有 `message_obj` 时访问 `event.message_obj` 或在绘图和回调流程中构建回复链导致 `AttributeError`。
- 确保在 `raw_message` 或 `message_obj` 不可用时，QQ @提及名称提取返回空映射，而不是抛出错误。
- 保证后台回调在生成失败时只接收仅包含错误的消息链（不包含多余的图片组件），并确保直接发送的后台任务在成功时仍会将图片组件传递给回调。

Enhancements:
- 添加共享的事件工具，用于安全获取消息 ID、根据可配置的引用回复模式构建回复组件，以及从 URL、文件系统路径、Base64 数据或回退内容构建健壮的图片组件。
- 更新绘图处理器、收集器、任务跟踪和 LLM 媒体工具，使其依赖新的安全消息 ID 和回复/图片辅助函数，从而改善在非消息驱动和模拟事件场景下的行为。
- 优化后台结果分发逻辑，使直接发送与回调之间的交互更可预测，并为失败的媒体生成任务提供更精简、更清晰的错误消息。
- 引入可配置的 `quote_reply_mode` 偏好，用于控制命令和工具在发送消息时何时包含回复引用。

Tests:
- 添加测试，用于覆盖在多种事件和数据条件下的安全消息 ID 获取、回复构建和图片组件构建，包括没有 `message_obj` 的事件以及会触发 `AttributeError` 的模拟对象。
- 添加测试，确保在启用 `direct_send_result` 时后台回调能接收包含图片的消息链，而在生成失败时只接收文本错误消息链。
- 扩展关于后台回调行为和基于配置的回复引用的测试，以验证新的事件工具和回调结果消息链语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden event handling and background media workflows when message objects are missing, while introducing shared utilities for safe reply and image component construction and making callback behavior more consistent.

Bug Fixes:
- Prevent AttributeError when accessing event.message_obj or building reply chains in drawing and callback flows where the underlying event has no message_obj.
- Ensure QQ mention name extraction returns an empty mapping instead of failing when raw_message or message_obj are unavailable.
- Guarantee background callbacks receive appropriate error-only chains without stray image components when generation fails, and that direct-send background tasks still pass image components to callbacks.

Enhancements:
- Add shared event utilities for safely obtaining message IDs, building reply components based on configurable quote-reply modes, and constructing robust image components from URLs, filesystem paths, Base64 data, or fallbacks.
- Update drawing handlers, collectors, task tracking, and LLM media tools to rely on the new safe message ID and reply/image helpers, improving behavior in non message-driven and mocked event scenarios.
- Refine background result dispatch logic so direct sending and callbacks interact more predictably, with simplified and clearer error messaging for failed media generation tasks.
- Introduce a configurable quote_reply_mode preference that controls when commands and tools include reply references in outgoing messages.

Tests:
- Add tests covering safe message ID retrieval, reply construction, and image component building under various event and data conditions, including events without message_obj or with AttributeError-raising mocks.
- Add tests ensuring background callbacks receive image chains when direct_send_result is enabled and only text error chains when generation fails.
- Extend tests for background callback behavior and configuration-driven reply quoting to validate the new event utility and callback result-chain semantics.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在消息对象缺失的情况下加强事件处理和后台媒体工作流，同时引入用于安全回复和图片组件构建的共享工具，并使回调行为更加一致。

Bug Fixes:
- 防止在底层事件没有 `message_obj` 时访问 `event.message_obj` 或在绘图和回调流程中构建回复链导致 `AttributeError`。
- 确保在 `raw_message` 或 `message_obj` 不可用时，QQ @提及名称提取返回空映射，而不是抛出错误。
- 保证后台回调在生成失败时只接收仅包含错误的消息链（不包含多余的图片组件），并确保直接发送的后台任务在成功时仍会将图片组件传递给回调。

Enhancements:
- 添加共享的事件工具，用于安全获取消息 ID、根据可配置的引用回复模式构建回复组件，以及从 URL、文件系统路径、Base64 数据或回退内容构建健壮的图片组件。
- 更新绘图处理器、收集器、任务跟踪和 LLM 媒体工具，使其依赖新的安全消息 ID 和回复/图片辅助函数，从而改善在非消息驱动和模拟事件场景下的行为。
- 优化后台结果分发逻辑，使直接发送与回调之间的交互更可预测，并为失败的媒体生成任务提供更精简、更清晰的错误消息。
- 引入可配置的 `quote_reply_mode` 偏好，用于控制命令和工具在发送消息时何时包含回复引用。

Tests:
- 添加测试，用于覆盖在多种事件和数据条件下的安全消息 ID 获取、回复构建和图片组件构建，包括没有 `message_obj` 的事件以及会触发 `AttributeError` 的模拟对象。
- 添加测试，确保在启用 `direct_send_result` 时后台回调能接收包含图片的消息链，而在生成失败时只接收文本错误消息链。
- 扩展关于后台回调行为和基于配置的回复引用的测试，以验证新的事件工具和回调结果消息链语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden event handling and background media workflows when message objects are missing, while introducing shared utilities for safe reply and image component construction and making callback behavior more consistent.

Bug Fixes:
- Prevent AttributeError when accessing event.message_obj or building reply chains in drawing and callback flows where the underlying event has no message_obj.
- Ensure QQ mention name extraction returns an empty mapping instead of failing when raw_message or message_obj are unavailable.
- Guarantee background callbacks receive appropriate error-only chains without stray image components when generation fails, and that direct-send background tasks still pass image components to callbacks.

Enhancements:
- Add shared event utilities for safely obtaining message IDs, building reply components based on configurable quote-reply modes, and constructing robust image components from URLs, filesystem paths, Base64 data, or fallbacks.
- Update drawing handlers, collectors, task tracking, and LLM media tools to rely on the new safe message ID and reply/image helpers, improving behavior in non message-driven and mocked event scenarios.
- Refine background result dispatch logic so direct sending and callbacks interact more predictably, with simplified and clearer error messaging for failed media generation tasks.
- Introduce a configurable quote_reply_mode preference that controls when commands and tools include reply references in outgoing messages.

Tests:
- Add tests covering safe message ID retrieval, reply construction, and image component building under various event and data conditions, including events without message_obj or with AttributeError-raising mocks.
- Add tests ensuring background callbacks receive image chains when direct_send_result is enabled and only text error chains when generation fails.
- Extend tests for background callback behavior and configuration-driven reply quoting to validate the new event utility and callback result-chain semantics.

</details>

</details>

Bug 修复：
- 当在绘图和回调流程中构造回复消息或访问 `event.message_obj` 时，如果 `message_obj` 缺失，避免触发 `AttributeError`。
- 确保后台回调在启用 `direct_send_result` 时仍能收到图像组件，并在 `raw_message` 或 `message_obj` 不存在时，为 QQ @提及名称提取返回安全的空映射。
- 保证第三方回调插件在底层事件不暴露该属性时看到的 `event.message_obj` 为 `None`，而不是抛出错误。

Enhancements:
- 引入共享的事件工具，用于安全获取消息 ID、构建回复组件，以及从 URL、文件路径或 Base64 数据构造图像组件。
- 更新绘图处理器、收集器、任务追踪以及 LLM 媒体工具以使用新的安全事件和消息 ID 辅助方法，从而在非消息驱动场景中提升稳定性。
- 简化后台结果分发逻辑，使直接发送与回调之间的协调更一致，并提供更清晰的失败信息，包括对后台图像生成的错误提示进行精简。

Tests:
- 添加测试，验证在启用 `direct_send_result` 时回调能够收到图像链，并且仅含错误的结果链会省略图像组件。
- 添加测试，确认安全事件封装在第三方回调中将 `message_obj` 暴露为 `None`，包括那些受限或模拟的、会抛出 `AttributeError` 的事件场景。
- 添加测试，覆盖在 `message_obj` 缺失时 `get_message_id`、`build_reply_component`、图像组件构造以及结果链构建的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在消息对象缺失的情况下加强事件处理和后台媒体工作流，同时引入用于安全回复和图片组件构建的共享工具，并使回调行为更加一致。

Bug Fixes:
- 防止在底层事件没有 `message_obj` 时访问 `event.message_obj` 或在绘图和回调流程中构建回复链导致 `AttributeError`。
- 确保在 `raw_message` 或 `message_obj` 不可用时，QQ @提及名称提取返回空映射，而不是抛出错误。
- 保证后台回调在生成失败时只接收仅包含错误的消息链（不包含多余的图片组件），并确保直接发送的后台任务在成功时仍会将图片组件传递给回调。

Enhancements:
- 添加共享的事件工具，用于安全获取消息 ID、根据可配置的引用回复模式构建回复组件，以及从 URL、文件系统路径、Base64 数据或回退内容构建健壮的图片组件。
- 更新绘图处理器、收集器、任务跟踪和 LLM 媒体工具，使其依赖新的安全消息 ID 和回复/图片辅助函数，从而改善在非消息驱动和模拟事件场景下的行为。
- 优化后台结果分发逻辑，使直接发送与回调之间的交互更可预测，并为失败的媒体生成任务提供更精简、更清晰的错误消息。
- 引入可配置的 `quote_reply_mode` 偏好，用于控制命令和工具在发送消息时何时包含回复引用。

Tests:
- 添加测试，用于覆盖在多种事件和数据条件下的安全消息 ID 获取、回复构建和图片组件构建，包括没有 `message_obj` 的事件以及会触发 `AttributeError` 的模拟对象。
- 添加测试，确保在启用 `direct_send_result` 时后台回调能接收包含图片的消息链，而在生成失败时只接收文本错误消息链。
- 扩展关于后台回调行为和基于配置的回复引用的测试，以验证新的事件工具和回调结果消息链语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden event handling and background media workflows when message objects are missing, while introducing shared utilities for safe reply and image component construction and making callback behavior more consistent.

Bug Fixes:
- Prevent AttributeError when accessing event.message_obj or building reply chains in drawing and callback flows where the underlying event has no message_obj.
- Ensure QQ mention name extraction returns an empty mapping instead of failing when raw_message or message_obj are unavailable.
- Guarantee background callbacks receive appropriate error-only chains without stray image components when generation fails, and that direct-send background tasks still pass image components to callbacks.

Enhancements:
- Add shared event utilities for safely obtaining message IDs, building reply components based on configurable quote-reply modes, and constructing robust image components from URLs, filesystem paths, Base64 data, or fallbacks.
- Update drawing handlers, collectors, task tracking, and LLM media tools to rely on the new safe message ID and reply/image helpers, improving behavior in non message-driven and mocked event scenarios.
- Refine background result dispatch logic so direct sending and callbacks interact more predictably, with simplified and clearer error messaging for failed media generation tasks.
- Introduce a configurable quote_reply_mode preference that controls when commands and tools include reply references in outgoing messages.

Tests:
- Add tests covering safe message ID retrieval, reply construction, and image component building under various event and data conditions, including events without message_obj or with AttributeError-raising mocks.
- Add tests ensuring background callbacks receive image chains when direct_send_result is enabled and only text error chains when generation fails.
- Extend tests for background callback behavior and configuration-driven reply quoting to validate the new event utility and callback result-chain semantics.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在消息对象缺失的情况下加强事件处理和后台媒体工作流，同时引入用于安全回复和图片组件构建的共享工具，并使回调行为更加一致。

Bug Fixes:
- 防止在底层事件没有 `message_obj` 时访问 `event.message_obj` 或在绘图和回调流程中构建回复链导致 `AttributeError`。
- 确保在 `raw_message` 或 `message_obj` 不可用时，QQ @提及名称提取返回空映射，而不是抛出错误。
- 保证后台回调在生成失败时只接收仅包含错误的消息链（不包含多余的图片组件），并确保直接发送的后台任务在成功时仍会将图片组件传递给回调。

Enhancements:
- 添加共享的事件工具，用于安全获取消息 ID、根据可配置的引用回复模式构建回复组件，以及从 URL、文件系统路径、Base64 数据或回退内容构建健壮的图片组件。
- 更新绘图处理器、收集器、任务跟踪和 LLM 媒体工具，使其依赖新的安全消息 ID 和回复/图片辅助函数，从而改善在非消息驱动和模拟事件场景下的行为。
- 优化后台结果分发逻辑，使直接发送与回调之间的交互更可预测，并为失败的媒体生成任务提供更精简、更清晰的错误消息。
- 引入可配置的 `quote_reply_mode` 偏好，用于控制命令和工具在发送消息时何时包含回复引用。

Tests:
- 添加测试，用于覆盖在多种事件和数据条件下的安全消息 ID 获取、回复构建和图片组件构建，包括没有 `message_obj` 的事件以及会触发 `AttributeError` 的模拟对象。
- 添加测试，确保在启用 `direct_send_result` 时后台回调能接收包含图片的消息链，而在生成失败时只接收文本错误消息链。
- 扩展关于后台回调行为和基于配置的回复引用的测试，以验证新的事件工具和回调结果消息链语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden event handling and background media workflows when message objects are missing, while introducing shared utilities for safe reply and image component construction and making callback behavior more consistent.

Bug Fixes:
- Prevent AttributeError when accessing event.message_obj or building reply chains in drawing and callback flows where the underlying event has no message_obj.
- Ensure QQ mention name extraction returns an empty mapping instead of failing when raw_message or message_obj are unavailable.
- Guarantee background callbacks receive appropriate error-only chains without stray image components when generation fails, and that direct-send background tasks still pass image components to callbacks.

Enhancements:
- Add shared event utilities for safely obtaining message IDs, building reply components based on configurable quote-reply modes, and constructing robust image components from URLs, filesystem paths, Base64 data, or fallbacks.
- Update drawing handlers, collectors, task tracking, and LLM media tools to rely on the new safe message ID and reply/image helpers, improving behavior in non message-driven and mocked event scenarios.
- Refine background result dispatch logic so direct sending and callbacks interact more predictably, with simplified and clearer error messaging for failed media generation tasks.
- Introduce a configurable quote_reply_mode preference that controls when commands and tools include reply references in outgoing messages.

Tests:
- Add tests covering safe message ID retrieval, reply construction, and image component building under various event and data conditions, including events without message_obj or with AttributeError-raising mocks.
- Add tests ensuring background callbacks receive image chains when direct_send_result is enabled and only text error chains when generation fails.
- Extend tests for background callback behavior and configuration-driven reply quoting to validate the new event utility and callback result-chain semantics.

</details>

</details>

</details>

</details>